### PR TITLE
Fix view definition capture in DataHub for Vertica schemas with uppercase letters

### DIFF
--- a/vertica_sqlalchemy_dialect/base.py
+++ b/vertica_sqlalchemy_dialect/base.py
@@ -838,7 +838,7 @@ class VerticaDialect(default.DefaultDialect):
                     """
                     SELECT VIEW_DEFINITION , table_name
                     FROM V_CATALOG.VIEWS
-                    WHERE table_schema='%(schema)s' 
+                    WHERE lower(table_schema)='%(schema)s' 
                     """
                     % {"schema": schema.lower()}
                 )


### PR DESCRIPTION
This PR fixes a bug where view definitions were not captured in DataHub when Vertica schema names contained uppercase letters. The `table_schema` column in `V_CATALOG.VIEWS` displays schema names exactly as they were created. For example, if a schema was created as `CREATE SCHEMA myschema1;`, it would be displayed as `myschema1`, while `CREATE SCHEMA mySchema2;` would be displayed as `mySchema2`, preserving the original casing.

The current code compares `table_schema` using `table_schema = lower(any_schema_in_the_database)`, which causes issues with schema names that have uppercase letters. 

This fix updates the query to use `lower(table_schema) = lower(any_schema_in_the_database)`, allowing DataHub to capture view definitions for schemas regardless of whether their names contain uppercase characters.

